### PR TITLE
:sparkles: Create self-containing HTML report

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,16 @@
 # main
 asmVersion=9.2
-guavaVersion=30.1.1-jre
+guavaVersion=31.0.1-jre
 j2htmlVersion=1.5.0
 fontmetricsVersion=1.0.0
+webjarsVersion=0.42
+bootstrapVersion=4.6.1
+bootstrapIconsVersion=1.7.0
+jqueryVersion=3.6.0
+tooltipsterVersion=4.2.8
+svgjsVersion=3.1.1
 # test
-junitVersion=5.8.0
+junitVersion=5.8.1
 assertjVersion=3.21.0
 commonsioVersion=2.11.0
 slf4jVersion=1.7.31

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,6 +9,12 @@ val asmVersion: String by project
 val guavaVersion: String by project
 val j2htmlVersion: String by project
 val fontmetricsVersion: String by project
+val webjarsVersion: String by project
+val bootstrapVersion: String by project
+val bootstrapIconsVersion: String by project
+val jqueryVersion: String by project
+val tooltipsterVersion: String by project
+val svgjsVersion: String by project
 val junitVersion: String by project
 val assertjVersion: String by project
 val slf4jVersion: String by project
@@ -20,6 +26,14 @@ dependencies {
     }
     implementation( "com.j2html:j2html:${j2htmlVersion}")
     implementation("org.javastack:fontmetrics:${fontmetricsVersion}")
+    implementation("org.webjars:webjars-locator-core:${webjarsVersion}") {
+        exclude(group = "com.fasterxml.jackson.core") // not used
+    }
+    runtimeOnly("org.webjars:bootstrap:${bootstrapVersion}")
+    runtimeOnly("org.webjars.npm:bootstrap-icons:${bootstrapIconsVersion}")
+    runtimeOnly("org.webjars:jquery:${jqueryVersion}")
+    runtimeOnly("org.webjars.npm:tooltipster:${tooltipsterVersion}")
+    runtimeOnly("org.webjars:svg.js:${svgjsVersion}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
@@ -28,7 +42,7 @@ dependencies {
     testImplementation("org.slf4j:slf4j-jdk14:${slf4jVersion}") // needed for fontmetrics
 }
 
-configure<JavaPluginConvention> {
+configure<JavaPluginExtension> {
     sourceCompatibility = JavaVersion.VERSION_11
 }
 

--- a/lib/src/main/java/de/obqo/decycle/configuration/Configuration.java
+++ b/lib/src/main/java/de/obqo/decycle/configuration/Configuration.java
@@ -41,6 +41,7 @@ import lombok.NonNull;
  *             .slicings(...)
  *             .constraints(...)
  *             .report(...)
+ *             .reportResourcesPrefix(...)
  *             .reportTitle(...)
  *             .minifyReport(...)
  *             .build()
@@ -72,6 +73,8 @@ public class Configuration {
 
     private final Appendable report;
 
+    private final String reportResourcesPrefix;
+
     private final String reportTitle;
 
     private final boolean minifyReport;
@@ -95,6 +98,9 @@ public class Configuration {
      * @param constraints  Set of additional constraints to be checked (Note: {@link CycleFree} is automatically
      *                     included)
      * @param report       Target of the HTML report (if {@code null}, then no report is written)
+     * @param reportResourcesPrefix Relative path that is prepended to linked CSS and JS resources in the HTML report.
+     *                              These resources must be created independently using
+     *                              {@link de.obqo.decycle.report.ResourcesExtractor#copyWebJarResources(java.io.File)}
      * @param reportTitle  HTML Title to be used in the generated report. Has no effect if no {@code report} was
      *                     configured.
      * @param minifyReport Whether the HTML report should be minified (default is {@code true}). Has no effect if no
@@ -110,6 +116,7 @@ public class Configuration {
             final Map<String, List<Pattern>> slicings,
             final Set<Constraint> constraints,
             final Appendable report,
+            final String reportResourcesPrefix,
             final String reportTitle,
             final Boolean minifyReport) {
         this.classpath = classpath;
@@ -119,6 +126,7 @@ public class Configuration {
         this.ignoring = requireNonNullElse(ignoring, List.of());
         this.constraints = requireNonNullElse(constraints, Set.of());
         this.report = report;
+        this.reportResourcesPrefix = requireNonNullElse(reportResourcesPrefix, "");
         this.reportTitle = reportTitle;
         this.minifyReport = !Boolean.FALSE.equals(minifyReport); // null -> true
 
@@ -172,7 +180,8 @@ public class Configuration {
                 .sorted(Comparator.comparing(Violation::getSliceType).thenComparing(Violation::getName))
                 .collect(toList());
         if (this.report != null) {
-            new HtmlReport(this.minifyReport).writeReport(this.graph, violations, this.report, this.reportTitle);
+            new HtmlReport(this.minifyReport).writeReport(this.graph, violations, this.report,
+                    this.reportResourcesPrefix, this.reportTitle);
         }
         return violations;
     }

--- a/lib/src/main/java/de/obqo/decycle/report/HtmlReport.java
+++ b/lib/src/main/java/de/obqo/decycle/report/HtmlReport.java
@@ -89,11 +89,11 @@ public class HtmlReport {
     private final IdMapper<Edge> edgeIds = new IdMapper<>("e");
 
     public void writeReport(final Graph graph, final List<Violation> violations, final Appendable out,
-            final String title) {
+            final String resourcesPrefix, final String title) {
 
         resetDynIds();
 
-        final HtmlTag html = buildHtml(graph, violations, title);
+        final HtmlTag html = buildHtml(graph, violations, resourcesPrefix, title);
 
         final Config config = Config.defaults().withTextEscaper(ImprovedTextEscaper::escape);
         try {
@@ -103,7 +103,8 @@ public class HtmlReport {
         }
     }
 
-    private HtmlTag buildHtml(final Graph graph, final List<Violation> violations, final String title) {
+    private HtmlTag buildHtml(final Graph graph, final List<Violation> violations, final String resourcesPrefix,
+            final String title) {
         final var sliceSections = graph.sliceTypes().stream()
                 .filter(Predicate.not(SliceType::isClassType))
                 .sorted()
@@ -118,39 +119,14 @@ public class HtmlReport {
                         title((title != null ? title + " - " : "") + "Decycle Report"),
                         link().withHref("data:image/svg+xml;base64," + base64FromFile_min("/report/icon.svg"))
                                 .withRel("icon").withType("image/svg+xml"),
-                        // https://getbootstrap.com/docs/4.6/getting-started/introduction/
-                        link().withRel("stylesheet")
-                                .withHref("https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css")
-                                .attr("integrity",
-                                        "sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l")
-                                .attr("crossorigin", "anonymous"),
-                        // https://icons.getbootstrap.com/#usage
-                        link().withRel("stylesheet")
-                                .withHref("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css")
-                                .attr("integrity",
-                                        "sha256-PDJQdTN7dolQWDASIoBVrjkuOEaI137FI15sqI3Oxu8=")
-                                .attr("crossorigin", "anonymous"),
+                        link().withRel("stylesheet").withHref(resourcesPrefix + "/bootstrap.min.css"),
+                        link().withRel("stylesheet").withHref(resourcesPrefix + "/bootstrap-icons.css"),
                         inlineStyle(this.minify, "/report/custom.css"),
-                        // https://code.jquery.com
-                        script().withSrc("https://code.jquery.com/jquery-3.6.0.min.js")
-                                .attr("integrity", "sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=")
-                                .attr("crossorigin", "anonymous"),
-                        // https://cdnjs.com/libraries/svg.js (required by tooltipster)
-                        script().withSrc("https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js")
-                                .attr("integrity",
-                                        "sha512-Aj0P6wguH3GVlCfbvTyMM90Zq886ePyMEYlZooRfx+3wcSYyUa6Uv4iAjoJ7yiWdKamqQzKp7yr/TkMQ8EEWbQ==")
-                                .attr("crossorigin", "anonymous"),
-                        // https://www.jsdelivr.com/package/npm/tooltipster
-                        script().withSrc("https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/tooltipster.bundle.min.js")
-                                .attr("integrity", "sha256-v8akIv8SCqn5f3mbVB7vEWprIizxPh6oV0yhao/dbB4=")
-                                .attr("crossorigin", "anonymous"),
-                        script().withSrc("https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/plugins/tooltipster/SVG/tooltipster-SVG.min.js")
-                                .attr("integrity", "sha256-b9JNfGq08bjI5FVdN3ZhjWBSRsOyF6ucACQwlvgVEU4=")
-                                .attr("crossorigin", "anonymous"),
-                        link().withRel("stylesheet")
-                                .withHref("https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/css/tooltipster.bundle.min.css")
-                                .attr("integrity", "sha256-Qc4lCfqZWYaHF5hgEOFrYzSIX9Rrxk0NPHRac+08QeQ=")
-                                .attr("crossorigin", "anonymous"),
+                        script().withSrc(resourcesPrefix + "/jquery.min.js"),
+                        script().withSrc(resourcesPrefix + "/svg.min.js"), // required by tooltipster
+                        script().withSrc(resourcesPrefix + "/tooltipster.bundle.min.js"),
+                        script().withSrc(resourcesPrefix + "/tooltipster-SVG.min.js"),
+                        link().withRel("stylesheet").withHref(resourcesPrefix + "/tooltipster.bundle.min.css"),
                         inlineScript(this.minify, "/report/custom.js")
                 ),
                 body(

--- a/lib/src/main/java/de/obqo/decycle/report/ResourcesExtractor.java
+++ b/lib/src/main/java/de/obqo/decycle/report/ResourcesExtractor.java
@@ -1,0 +1,37 @@
+package de.obqo.decycle.report;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Objects;
+
+import org.webjars.WebJarAssetLocator;
+
+public class ResourcesExtractor {
+
+    private static final WebJarAssetLocator locator = new WebJarAssetLocator();
+
+    public static void copyWebJarResources(final File targetDir) throws IOException {
+        copyResource(targetDir, "bootstrap", "bootstrap.min.css");
+        copyResource(targetDir, "bootstrap-icons", "bootstrap-icons.css");
+        copyResource(targetDir, "bootstrap-icons", "fonts/bootstrap-icons.woff");
+        copyResource(targetDir, "bootstrap-icons", "fonts/bootstrap-icons.woff2");
+        copyResource(targetDir, "jquery", "jquery.min.js");
+        copyResource(targetDir, "tooltipster", "tooltipster.bundle.min.js");
+        copyResource(targetDir, "tooltipster", "tooltipster.bundle.min.css");
+        copyResource(targetDir, "tooltipster", "tooltipster-SVG.min.js");
+        copyResource(targetDir, "svg.js", "svg.min.js");
+    }
+
+    private static void copyResource(final File targetDir, final String webjar, final String file) throws IOException {
+        final File targetFile = new File(targetDir, file);
+        targetFile.getParentFile().mkdirs();
+        final String fullPath = locator.getFullPath(webjar, file);
+        final InputStream inputStream = locator.getClass().getClassLoader().getResourceAsStream(fullPath);
+        Objects.requireNonNull(inputStream, () -> String.format("Cannot read resource %s", fullPath));
+        Files.copy(inputStream, targetFile.toPath(), REPLACE_EXISTING);
+    }
+}

--- a/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldReportAllDependencies.html
+++ b/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldReportAllDependencies.html
@@ -7,8 +7,8 @@
             Decycle Report
         </title>
         <link href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9ImJsYWNrIiB2aWV3Qm94PSIwIDAgMTYgMTYiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNMCAwbC0xLjUtM2EuMzUuMzUgMCAwIDEgLjQtLjQ1bDEuMTEuMyAxLjExLS4zYS4zNS4zNSAwIDAgMSAuNC40NXoiIC8+PGcgaWQ9ImUiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTcuOTcgNC41YTQgNCAwIDEgMC0zLjk3IDMuNXYtMWEzIDMgMCAwIDEtMi45NS0yLjV6bS0xLjAyLTFhMyAzIDAgMCAwLTUuOSAweiIgdHJhbnNmb3JtPSJyb3RhdGUoLTQ1IDQgNCkiIC8+PHVzZSB4bGluazpocmVmPSIjYSIgeD0iNy43NSIgeT0iNSIgdHJhbnNmb3JtPSJyb3RhdGUoLTEzMiA3Ljc1IDUpIiAvPjwvZz48ZyBpZD0iYyI+PHBhdGggZD0iTTggMTVhNyA3IDAgMSAxIDctN2EuNSAwLjc1IDAgMSAxLTEgMGE2IDYgMCAxIDAtNiA2eiIgdHJhbnNmb3JtPSJyb3RhdGUoNDUsIDgsIDgpIi8+PHVzZSB4bGluazpocmVmPSIjYSIgeD0iNC44IiB5PSIxNCIgdHJhbnNmb3JtPSJyb3RhdGUoLTQyIDQuOCAxNCkiLz48L2c+PC9kZWZzPjx1c2UgeGxpbms6aHJlZj0iI2UiIHg9IjQiIHk9IjQiIC8+PHVzZSB4bGluazpocmVmPSIjYyIgeD0iMCIgeT0iMCIgLz48L3N2Zz4=" rel="icon" type="image/svg+xml">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" integrity="sha256-PDJQdTN7dolQWDASIoBVrjkuOEaI137FI15sqI3Oxu8=" crossorigin="anonymous">
+        <link rel="stylesheet" href="resources/bootstrap.min.css">
+        <link rel="stylesheet" href="resources/bootstrap-icons.css">
         <style>
             html {
                 font-size: 14px;
@@ -159,15 +159,15 @@
                 padding: 6px;
             }
         </style>
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous">
+        <script src="resources/jquery.min.js">
         </script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js" integrity="sha512-Aj0P6wguH3GVlCfbvTyMM90Zq886ePyMEYlZooRfx+3wcSYyUa6Uv4iAjoJ7yiWdKamqQzKp7yr/TkMQ8EEWbQ==" crossorigin="anonymous">
+        <script src="resources/svg.min.js">
         </script>
-        <script src="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/tooltipster.bundle.min.js" integrity="sha256-v8akIv8SCqn5f3mbVB7vEWprIizxPh6oV0yhao/dbB4=" crossorigin="anonymous">
+        <script src="resources/tooltipster.bundle.min.js">
         </script>
-        <script src="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/plugins/tooltipster/SVG/tooltipster-SVG.min.js" integrity="sha256-b9JNfGq08bjI5FVdN3ZhjWBSRsOyF6ucACQwlvgVEU4=" crossorigin="anonymous">
+        <script src="resources/tooltipster-SVG.min.js">
         </script>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/css/tooltipster.bundle.min.css" integrity="sha256-Qc4lCfqZWYaHF5hgEOFrYzSIX9Rrxk0NPHRac+08QeQ=" crossorigin="anonymous">
+        <link rel="stylesheet" href="resources/tooltipster.bundle.min.css">
         <script>
             $(function() {
               // toggle display function for class references

--- a/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldWriteReport.html
+++ b/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldWriteReport.html
@@ -7,8 +7,8 @@
             j2html - Decycle Report
         </title>
         <link href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9ImJsYWNrIiB2aWV3Qm94PSIwIDAgMTYgMTYiPjxkZWZzPjxwYXRoIGlkPSJhIiBkPSJNMCAwbC0xLjUtM2EuMzUuMzUgMCAwIDEgLjQtLjQ1bDEuMTEuMyAxLjExLS4zYS4zNS4zNSAwIDAgMSAuNC40NXoiIC8+PGcgaWQ9ImUiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTcuOTcgNC41YTQgNCAwIDEgMC0zLjk3IDMuNXYtMWEzIDMgMCAwIDEtMi45NS0yLjV6bS0xLjAyLTFhMyAzIDAgMCAwLTUuOSAweiIgdHJhbnNmb3JtPSJyb3RhdGUoLTQ1IDQgNCkiIC8+PHVzZSB4bGluazpocmVmPSIjYSIgeD0iNy43NSIgeT0iNSIgdHJhbnNmb3JtPSJyb3RhdGUoLTEzMiA3Ljc1IDUpIiAvPjwvZz48ZyBpZD0iYyI+PHBhdGggZD0iTTggMTVhNyA3IDAgMSAxIDctN2EuNSAwLjc1IDAgMSAxLTEgMGE2IDYgMCAxIDAtNiA2eiIgdHJhbnNmb3JtPSJyb3RhdGUoNDUsIDgsIDgpIi8+PHVzZSB4bGluazpocmVmPSIjYSIgeD0iNC44IiB5PSIxNCIgdHJhbnNmb3JtPSJyb3RhdGUoLTQyIDQuOCAxNCkiLz48L2c+PC9kZWZzPjx1c2UgeGxpbms6aHJlZj0iI2UiIHg9IjQiIHk9IjQiIC8+PHVzZSB4bGluazpocmVmPSIjYyIgeD0iMCIgeT0iMCIgLz48L3N2Zz4=" rel="icon" type="image/svg+xml">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" integrity="sha256-PDJQdTN7dolQWDASIoBVrjkuOEaI137FI15sqI3Oxu8=" crossorigin="anonymous">
+        <link rel="stylesheet" href="resources/bootstrap.min.css">
+        <link rel="stylesheet" href="resources/bootstrap-icons.css">
         <style>
             html {
                 font-size: 14px;
@@ -159,15 +159,15 @@
                 padding: 6px;
             }
         </style>
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous">
+        <script src="resources/jquery.min.js">
         </script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js" integrity="sha512-Aj0P6wguH3GVlCfbvTyMM90Zq886ePyMEYlZooRfx+3wcSYyUa6Uv4iAjoJ7yiWdKamqQzKp7yr/TkMQ8EEWbQ==" crossorigin="anonymous">
+        <script src="resources/svg.min.js">
         </script>
-        <script src="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/tooltipster.bundle.min.js" integrity="sha256-v8akIv8SCqn5f3mbVB7vEWprIizxPh6oV0yhao/dbB4=" crossorigin="anonymous">
+        <script src="resources/tooltipster.bundle.min.js">
         </script>
-        <script src="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/js/plugins/tooltipster/SVG/tooltipster-SVG.min.js" integrity="sha256-b9JNfGq08bjI5FVdN3ZhjWBSRsOyF6ucACQwlvgVEU4=" crossorigin="anonymous">
+        <script src="resources/tooltipster-SVG.min.js">
         </script>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tooltipster@4.2.8/dist/css/tooltipster.bundle.min.css" integrity="sha256-Qc4lCfqZWYaHF5hgEOFrYzSIX9Rrxk0NPHRac+08QeQ=" crossorigin="anonymous">
+        <link rel="stylesheet" href="resources/tooltipster.bundle.min.css">
         <script>
             $(function() {
               // toggle display function for class references

--- a/plugin-gradle/src/main/java/de/obqo/decycle/gradle/DecycleWorker.java
+++ b/plugin-gradle/src/main/java/de/obqo/decycle/gradle/DecycleWorker.java
@@ -14,6 +14,7 @@ import de.obqo.decycle.configuration.Configuration;
 import de.obqo.decycle.configuration.NamedPattern;
 import de.obqo.decycle.configuration.Pattern;
 import de.obqo.decycle.configuration.UnnamedPattern;
+import de.obqo.decycle.report.ResourcesExtractor;
 import de.obqo.decycle.slicer.IgnoredDependency;
 
 import java.io.File;
@@ -59,7 +60,10 @@ public abstract class DecycleWorker implements WorkAction<DecycleWorkerParameter
         reportFile.getParentFile().mkdirs();
 
         try (final FileWriter writer = new FileWriter(reportFile)) {
+            final String resourcesDirName = createResourcesIfRequired(reportFile);
+
             builder.report(writer);
+            builder.reportResourcesPrefix(resourcesDirName);
             builder.reportTitle(reportTitle);
 
             final Configuration decycleConfig = builder.build();
@@ -83,6 +87,16 @@ public abstract class DecycleWorker implements WorkAction<DecycleWorkerParameter
         } catch (final IOException ioException) {
             throw new GradleException(ioException.getMessage(), ioException);
         }
+    }
+
+    private String createResourcesIfRequired(final File reportFile) throws IOException {
+        final String resourcesDirName = "resources-" + Configuration.class.getPackage().getImplementationVersion();
+        final File resourcesDir = new File(reportFile.getParentFile(), resourcesDirName);
+        if (!resourcesDir.exists()) {
+            resourcesDir.mkdirs();
+            ResourcesExtractor.copyWebJarResources(resourcesDir);
+        }
+        return resourcesDirName;
     }
 
     // Helper methods for converting the plugin's configuration (or extension) instances into decycle objects.


### PR DESCRIPTION
- decycle now provides all required external css and js files used in
  the report, so opening the report doesn't require downloading external
  files from public CDN sites