### PR TITLE
:sparkles: Hide anonymous classes in the report

### DIFF
--- a/lib/src/main/java/de/obqo/decycle/analysis/GraphBuilder.java
+++ b/lib/src/main/java/de/obqo/decycle/analysis/GraphBuilder.java
@@ -21,6 +21,7 @@ class GraphBuilder {
 
     private static final Pattern singlePattern = Pattern.compile("\\[*L([\\w/$]+);");
     private static final Pattern multiPattern = Pattern.compile("(?<=L)([\\w/$]+)(?=[;<])");
+    private static final Pattern anonymousClassPattern = Pattern.compile("\\$\\d+(?!\\w)");
 
     private final Graph graph;
     private Node currentNode;
@@ -32,7 +33,9 @@ class GraphBuilder {
     }
 
     static Node classNodeFromTypeName(final String slashSeparatedName) {
-        return Node.classNode(slashSeparatedName.replace('/', '.'));
+        final String fullClassName = slashSeparatedName.replace('/', '.');
+        // remove all anonymous class names ($<number> like $1 or $345)
+        return Node.classNode(anonymousClassPattern.matcher(fullClassName).replaceAll(""));
     }
 
     static Node classNodeFromSingleType(final String singleTypeDescription) {

--- a/lib/src/test/java/de/obqo/decycle/analysis/GraphBuilderTest.java
+++ b/lib/src/test/java/de/obqo/decycle/analysis/GraphBuilderTest.java
@@ -1,0 +1,39 @@
+package de.obqo.decycle.analysis;
+
+import static de.obqo.decycle.model.SliceType.classType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import de.obqo.decycle.model.Node;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class GraphBuilderTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldCreateClassNodeFromTypeName(final String slashSeparatedName, final String expectedNodeName) {
+        // when
+        final Node node = GraphBuilder.classNodeFromTypeName(slashSeparatedName);
+
+        // then
+        assertThat(node.hasType(classType())).isTrue();
+        assertThat(node.getName()).isEqualTo(expectedNodeName);
+    }
+
+    static Stream<Arguments> shouldCreateClassNodeFromTypeName() {
+        return Stream.of(
+                arguments("de/obqo/decycle/Test", "de.obqo.decycle.Test"),
+                arguments("de/obqo/decycle/Test$1", "de.obqo.decycle.Test"),
+                arguments("de/obqo/decycle/Test$1$23", "de.obqo.decycle.Test"),
+                arguments("de/obqo/decycle/Test$56$Inner", "de.obqo.decycle.Test$Inner"),
+                arguments("de/obqo/decycle/Test$2Local", "de.obqo.decycle.Test$2Local"),
+                arguments("de/obqo/decycle/Test$23Local", "de.obqo.decycle.Test$23Local"),
+                arguments("de/obqo/decycle/Test$1$23Local$4", "de.obqo.decycle.Test$23Local")
+        );
+    }
+}

--- a/lib/src/test/java/de/obqo/decycle/demo/base/from/FromClass.java
+++ b/lib/src/test/java/de/obqo/decycle/demo/base/from/FromClass.java
@@ -99,6 +99,9 @@ public class FromClass<@TypeParamAnnotation T extends GenericTypeForClass> exten
             void localClassMethod() {
                 var x = new BaseInterface<@TypeUseAnnotation Integer>() { // expands to FromClass$1LocalClass$1
 
+                    Object y = new BaseInterface<@TypeUseAnnotation Integer>() { // expands to FromClass$1LocalClass$1$1
+
+                    };
                 };
             }
         }
@@ -107,6 +110,11 @@ public class FromClass<@TypeParamAnnotation T extends GenericTypeForClass> exten
     }
 
     public void otherMethod(Object o) {
+
+        class LocalClass extends ReturnType { // expands to FromClass$2LocalClass
+
+        }
+
         if (o instanceof InstanceOfType) {
             var x = (TypeCast) o;
 

--- a/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldReportAllDependencies.html
+++ b/lib/src/test/resources/de/obqo/decycle/configuration/ConfigurationTest-shouldReportAllDependencies.html
@@ -420,6 +420,15 @@
                                                 de.obqo.decycle.demo.base.from.FromClass$1LocalClass
                                             </span>
                                              &rarr;&nbsp;
+                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.to.BaseInterface">
+                                                de.obqo.decycle.demo.base.to.BaseInterface
+                                            </span>
+                                        </li>
+                                        <li>
+                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.from.FromClass$1LocalClass">
+                                                de.obqo.decycle.demo.base.from.FromClass$1LocalClass
+                                            </span>
+                                             &rarr;&nbsp;
                                             <span class="class-node" data-name="de.obqo.decycle.demo.base.to.LocalTypeAnnotation">
                                                 de.obqo.decycle.demo.base.to.LocalTypeAnnotation
                                             </span>
@@ -443,21 +452,12 @@
                                             </span>
                                         </li>
                                         <li>
-                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.from.FromClass$1LocalClass$1">
-                                                de.obqo.decycle.demo.base.from.FromClass$1LocalClass$1
+                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.from.FromClass$2LocalClass">
+                                                de.obqo.decycle.demo.base.from.FromClass$2LocalClass
                                             </span>
                                              &rarr;&nbsp;
-                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.to.BaseInterface">
-                                                de.obqo.decycle.demo.base.to.BaseInterface
-                                            </span>
-                                        </li>
-                                        <li>
-                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.from.FromClass$1LocalClass$1">
-                                                de.obqo.decycle.demo.base.from.FromClass$1LocalClass$1
-                                            </span>
-                                             &rarr;&nbsp;
-                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.to.TypeUseAnnotation">
-                                                de.obqo.decycle.demo.base.to.TypeUseAnnotation
+                                            <span class="class-node" data-name="de.obqo.decycle.demo.base.to.ReturnType">
+                                                de.obqo.decycle.demo.base.to.ReturnType
                                             </span>
                                         </li>
                                         <li>


### PR DESCRIPTION
Dependencies of anonymous classes are difficult to understand since the bytecode class name is only a dollar character and a number. There's no simple mapping from this name to the location in the source code. Moreover, anonymous classes are heavily used in functional languages like Kotlin and will therefore pollute the generated HTML report.

For this reason, decycle will hide anonymous classes in the report. Any dependency will be treated as if it belongs to the parent class.

Example:
a dependency `Foo$1 -> Bar` will now be displayed as `Foo -> Bar`