### PR TITLE
:children_crossing: Print generated report as URI

### DIFF
--- a/lib/src/main/java/de/obqo/decycle/check/Constraint.java
+++ b/lib/src/main/java/de/obqo/decycle/check/Constraint.java
@@ -47,7 +47,7 @@ public interface Constraint {
         }
 
         public static String displayString(final List<Violation> violations) {
-            return violations.stream().map(Constraint.Violation::displayString).collect(joining("\n"));
+            return violations.stream().map(Constraint.Violation::displayString).collect(joining(System.lineSeparator()));
         }
     }
 

--- a/lib/src/main/java/de/obqo/decycle/configuration/Configuration.java
+++ b/lib/src/main/java/de/obqo/decycle/configuration/Configuration.java
@@ -109,7 +109,7 @@ public class Configuration {
      */
     @Builder
     private Configuration(
-            final String classpath,
+            @NonNull final String classpath,
             final List<String> including,
             final List<String> excluding,
             final List<IgnoredDependency> ignoring,
@@ -191,13 +191,14 @@ public class Configuration {
      */
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder("Decycle {\n");
-        builder.append("  classpath: ").append(this.classpath).append("\n");
-        builder.append("  including: ").append(this.including).append("\n");
-        builder.append("  excluding: ").append(this.excluding).append("\n");
-        builder.append("  ignoring: ").append(this.ignoring).append("\n");
-        builder.append("  slicings: ").append(this.slicings).append("\n");
-        builder.append("  constraints: ").append(this.constraints).append("\n");
+        final String nl = System.lineSeparator();
+        final StringBuilder builder = new StringBuilder("Decycle {").append(nl);
+        builder.append("  classpath: ").append(this.classpath).append(nl);
+        builder.append("  including: ").append(this.including).append(nl);
+        builder.append("  excluding: ").append(this.excluding).append(nl);
+        builder.append("  ignoring: ").append(this.ignoring).append(nl);
+        builder.append("  slicings: ").append(this.slicings).append(nl);
+        builder.append("  constraints: ").append(this.constraints).append(nl);
         builder.append("}");
         return builder.toString();
     }

--- a/plugin-gradle/src/test/java/de/obqo/decycle/gradle/DecyclePluginFunctionalTest.java
+++ b/plugin-gradle/src/test/java/de/obqo/decycle/gradle/DecyclePluginFunctionalTest.java
@@ -160,10 +160,11 @@ public class DecyclePluginFunctionalTest {
     @Test
     void shouldSucceedWithIgnoreFailures() {
         final BuildResult result = build("ignoreFailures.gradle");
+        final String nl = System.lineSeparator();
         assertBuildResult(result, TaskOutcome.SUCCESS, "decycleMain")
-                .contains("\nViolations detected: Violation(slicing=Package, name=cycle, " +
-                        "dependencies=[demo.cycle.a → demo.cycle.b, demo.cycle.b → demo.cycle.a])\n")
-                .contains("See the report at: ");
+                .contains(nl + "Violations detected: Violation(slicing=Package, name=cycle, " +
+                        "dependencies=[demo.cycle.a → demo.cycle.b, demo.cycle.b → demo.cycle.a])" + nl)
+                .contains(nl + "See the report at: file:/");
     }
 
     @Test

--- a/plugin-maven/src/main/java/de/obqo/decycle/maven/AbstractDecycleMojo.java
+++ b/plugin-maven/src/main/java/de/obqo/decycle/maven/AbstractDecycleMojo.java
@@ -182,8 +182,10 @@ abstract class AbstractDecycleMojo extends AbstractMojo {
         if (!violations.isEmpty()) {
             logHandler.accept("Violations detected: " + Constraint.Violation.displayString(violations));
             if (report != null) {
-                logHandler.accept("See the report at: " + report);
+                logHandler.accept("See the report at: " + report.toURI());
             }
+        } else if (report != null) {
+            log.info("Decycle HTML report is available at: " + report.toURI());
         }
         return violations;
     }


### PR DESCRIPTION
- enables one-click open in the terminal
- respect OS specific line separators